### PR TITLE
Support showdown options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ You can also pass a bound value:
 {{markdown-to-html markdown=postContent}}
 ```
 
+### Showdown Options
+
+You can use [configuration settings from Showdown][showdown-config]:
+
+```handlebars
+{{markdown-to-html
+  markdown=postContent
+  strikethrough=true
+  literalMidWordUnderscores=true
+  simplifiedAutoLink=true}}
+```
+
+[showdown-config]: https://github.com/showdownjs/showdown#valid-options
+
 ## Dependencies
 * [Showdown](https://github.com/showdownjs/showdown)
 

--- a/addon/components/markdown-to-html.js
+++ b/addon/components/markdown-to-html.js
@@ -8,6 +8,28 @@ export default Ember.Component.extend({
   },
 
   html: Ember.computed('markdown', function() {
+    var showdownOptions = this.getProperties(
+      'omitExtraWLInCodeBlocks',
+      'noHeaderId',
+      'prefixHeaderId',
+      'parseImgDimensions',
+      'headerLevelStart',
+      'simplifiedAutoLink',
+      'literalMidWordUnderscores',
+      'strikethrough',
+      'tables',
+      'tablesHeaderId',
+      'ghCodeBlocks',
+      'tasklists',
+      'smoothLivePreview'
+    );
+
+    for (var option in showdownOptions) {
+      if (showdownOptions.hasOwnProperty(option)) {
+        this.converter.setOption(option, showdownOptions[option]);
+      }
+    }
+
     var source = this.get('markdown') || '';
     return new Ember.Handlebars.SafeString(this.converter.makeHtml(source));
   })

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -41,3 +41,21 @@ test('it inserts <br> tag', function(assert) {
 
   assert.equal(component.get('html').toString(), expectedHtml);
 });
+
+test('supports setting showdown options', function(assert) {
+  assert.expect(1);
+
+  var component = this.subject();
+  this.append();
+
+  Ember.run(function() {
+    component.set('markdown', '# title\nI ~~dislike~~ enjoy visiting http://www.google.com');
+    component.set('simplifiedAutoLink', true);
+    component.set('headerLevelStart', 3);
+    component.set('strikethrough', true);
+  });
+
+  var expectedHtml = '<h3 id="title">title</h3>\n\n<p>I <del>dislike</del> enjoy visiting <a href="http://www.google.com">http://www.google.com</a></p>';
+
+  assert.equal(component.get('html').toString(), expectedHtml);
+});


### PR DESCRIPTION
This branch:

* updates Showdown to 1.2.2
* allows showdown options to be set on the converter prior to processing text

I've included tests exercising three of the showdown options.