### PR TITLE
Adds support for Showdown Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,31 @@ You can use [configuration settings from Showdown][showdown-config]:
 
 [showdown-config]: https://github.com/showdownjs/showdown#valid-options
 
+### Showdown Extensions
+
+You can load [Showdown Extensions](showdown-extensions) by specifying the
+"extensions" property when initializing your component:
+
+```handlebars
+{{markdown-to-html
+  markdown=postContent
+  extensions=myExtensionList}}
+```
+(`myExtensionList` should be an array of extension names as strings)
+
+Note that you'll have to register your extensions with Showdown first.
+Here's an example:
+
+```js
+window.showdown.extension("demo", function() {
+  return [{
+    // ... your extension properties here ...
+  }];
+});
+```
+
+[showdown-extensions]: https://github.com/showdownjs/showdown/wiki/extensions
+
 ## Dependencies
 * [Showdown](https://github.com/showdownjs/showdown)
 

--- a/addon/components/markdown-to-html.js
+++ b/addon/components/markdown-to-html.js
@@ -4,7 +4,10 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   init: function() {
     this._super();
-    this.converter = new showdown.Converter();
+
+    this.converter = new showdown.Converter({
+      extensions: (this.get("extensions") || [])
+    });
   },
 
   html: Ember.computed('markdown', function() {

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -59,3 +59,28 @@ test('supports setting showdown options', function(assert) {
 
   assert.equal(component.get('html').toString(), expectedHtml);
 });
+
+test('it supports loading showdown extensions', function(assert) {
+  assert.expect(1);
+
+  window.showdown.extension("demo", function() {
+    return [{
+      type: "lang",
+      regex: "this is an ember showdown!",
+      replace: function() {
+        return "no it isn't!";
+      }
+    }];
+  });
+
+  var component = this.subject({ extensions: ['demo'] });
+  this.append();
+
+  Ember.run(function() {
+    component.set("markdown", "this is an ember showdown!");
+  });
+
+  var expectedHtml = "<p>no it isn't!</p>";
+  assert.equal(component.get('html').toString(), expectedHtml);
+
+});


### PR DESCRIPTION
This PR adds support for loading [Showdown Extensions](https://github.com/showdownjs/showdown/wiki/extensions) to the add-on, complete with tests and docs.

The way I've implemented this means that if you change the `extensions` property post-init then that won't be reflected. We could potentially refactor to make `converter` a computed property based on that property, but I was unsure about the potential performance implications of that...? 

(Also, related to the above, should we be using the `attrs` there now rather than init? I'm nervous about that leading to a new `Converter` instance every time the `markdown` property changes!)