### PR TITLE
Adds support for sub expressions

### DIFF
--- a/app/helpers/sample.js
+++ b/app/helpers/sample.js
@@ -1,1 +1,0 @@
-export { default, sample } from 'ember-cli-showdown/helpers/sample';

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "ember": "1.13.7",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
+    "ember-cli-test-loader": "ember-cli-test-loader#0.2.2",
     "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-qunit": "0.4.9",

--- a/tests/dummy/app/helpers/safestring-sub-expression.js
+++ b/tests/dummy/app/helpers/safestring-sub-expression.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
-export function sample(params/*, hash*/) {
+export function safestringSubExpression(params/*, hash*/) {
   return Ember.String.htmlSafe(params);
 }
 
-export default Ember.Helper.helper(sample);
+export default Ember.Helper.helper(safestringSubExpression);

--- a/tests/dummy/app/helpers/simple-sub-expression.js
+++ b/tests/dummy/app/helpers/simple-sub-expression.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
-export function sample(params/*, hash*/) {
-  return params;
+export function simpleSubExpression(params/*, hash*/) {
+  return params[0];
 }
 
-export default Ember.Helper.helper(sample);
+export default Ember.Helper.helper(simpleSubExpression);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,7 +3,7 @@
 {{textarea value=editableText}}
 {{markdown-to-html markdown=editableText}}
 
-{{markdown-to-html markdown=(safestring-sub-expression '#Converting <em>SafeString</em> sub expressions to Markdown is cool <script>alert("nope")</script>')}}
-{{markdown-to-html markdown=(simple-sub-expression '#Converting simple sub expresions to Markdown is also cool [link](google.com)')}}
+{{markdown-to-html markdown=(simple-sub-expression '#Converting simple sub expresions to Markdown is cool [link](google.com)')}}
+{{markdown-to-html markdown=(safestring-sub-expression '#Converting <em>SafeString</em> sub expressions to Markdown is also cool <script>alert("nope")</script>')}}
 
 {{outlet}}

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -27,22 +27,6 @@ test('it produces markdown', function(assert) {
   assert.equal(component.$().html().toString().trim(), expectedHtml);
 });
 
-test('it produces markdown from a Handlebars sub-expression', function(assert) {
-  assert.expect(2);
-
-  var component = this.subject();
-  this.render();
-
-  Ember.run(function() {
-    component.set('markdown', ['##Hello, [world](#)']);
-  });
-
-  var expectedHtml = '<h2 id="helloworld">Hello, <a href="#">world</a></h2>';
-
-  assert.equal(component.get('html').toString(), expectedHtml);
-  assert.equal(component.$().html().toString().trim(), expectedHtml);
-});
-
 test('it produces markdown from a Handlebars sub-expression that returns a SafeString', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
This PR adds support for passing in sub-expressions whether they export a basic result or a SafeString result. Allows you to nest your own helper and  do:

```
{{markdown-to-html markdown=(my-helper someStringOrWhatever)}}
```
Also needed to lock jquery versions in bower.json because was throwing "Assertion Failed: Ember Views require jQuery between 1.7 and 2.1." See https://github.com/emberjs/ember.js/pull/12787 for more info. 