### PR TITLE
Revert "Only import the jQuery plugin outside of fastboot"

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,8 @@ module.exports = {
   included: function showdownIncluded(app) {
     this._super.included.apply(this, arguments);
 
-    if (!process.env.EMBER_CLI_FASTBOOT) {
-      // If this flag is present, the addon is being built in FastBoot
-      // The jQuery plugin causes FastBoot to crash, so only import in
-      // the browser build
-      var bower = app.bowerDirectory;
+    var bower = app.bowerDirectory;
 
-      app.import(bower + '/showdown/dist/showdown.js');
-    }
+    app.import(bower + '/showdown/dist/showdown.js');
   }
 };


### PR DESCRIPTION
Reverts gcollazo/ember-cli-showdown#17

Showdown does not have a dependency on jQuery and there is nothing indicating it will not run in node land.