### PR TITLE
Allows to nest ember-cli-showdown in other addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,10 @@ module.exports = {
   },
 
   included: function showdownIncluded(app) {
-    this._super.included.apply(this, arguments);
+    if (app.app) {
+      app = app.app;
+    }
+    this._super.included.call(this, app);
 
     if (isFastBoot()) {
       this.importFastBootDependencies(app);


### PR DESCRIPTION
Trying to use `ember-cli-showdown` in another addon (typical nesting case), I realised the addon lacks this ability.

It's a well-known problem in ember-cli (see https://github.com/ember-cli/ember-cli/issues/4616), and while a solution has not been found (see https://github.com/ember-cli/ember-cli/issues/6042), the proposed PR is the most commonly used workaround (see https://github.com/rwjblue/ember-cli-pretender/commit/33e5794f5aef545f00995435d08cb471e79a3bae#diff-168726dbe96b3ce427e7fedce31bb0bcR8 for another exemple).

Thanks for the addon!