### PR TITLE
Update included hook for nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,15 +19,12 @@ module.exports = {
   included: function showdownIncluded(app) {
     this._super.included.apply(this, arguments);
 
-    // support for using ember-cli-showdown as a deeply nested addon
-    if (typeof app.import !== 'function' && app.app) {
-      app = app.app;
-    }
+    var host = this._findHost();
 
     if (isFastBoot()) {
-      this.importFastBootDependencies(app);
+      this.importFastBootDependencies(host);
     } else {
-      this.importBrowserDependencies(app);
+      this.importBrowserDependencies(host);
     }
   },
 
@@ -52,13 +49,13 @@ module.exports = {
     var whitelist = pkg.fastbootDependencies;
 
     if (!whitelist || whitelist && !~whitelist.indexOf('showdown')) {
-      throw new Error("[ember-cli-showdown] showdown is missing from package.json's fastbootDependencies.\nSee: https://github.com/ember-fastboot/ember-cli-fastboot#whitelisting-packages")
+      throw new Error("[ember-cli-showdown] showdown is missing from package.json's fastbootDependencies.\nSee: https://github.com/ember-fastboot/ember-cli-fastboot#whitelisting-packages");
     }
 
-    app.import('vendor/fastboot-showdown.js');
+    this.import('vendor/fastboot-showdown.js');
   },
 
   importBrowserDependencies: function(app) {
-    app.import(app.bowerDirectory + '/showdown/dist/showdown.js');
+    this.import(app.bowerDirectory + '/showdown/dist/showdown.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-cli-babel": "^5.1.3",
     "ember-cli-htmlbars": "^1.0.8",
     "ember-cli-htmlbars-inline-precompile": "^0.3.2",
+    "ember-cli-import-polyfill": "^0.2.0",
     "rsvp": "^3.2.1"
   },
   "ember-addon": {


### PR DESCRIPTION
I update the to add the feature to be nested into another addon. I add `ember-cli-import-polyfill` to have access to the new `this.import` syntax and the polyfill add a nice function  `_findHost` to retrieve informations of the top parent app.
