### PR TITLE
Fix for #38 GitHub code blocks are rendered incorrectly

### DIFF
--- a/addon/components/markdown-to-html.js
+++ b/addon/components/markdown-to-html.js
@@ -20,7 +20,7 @@ const ShowdownComponent = Ember.Component.extend({
     let showdownOptions = this.getProperties(get(this, 'defaultOptionKeys'));
 
     for (let option in showdownOptions) {
-      if (showdownOptions.hasOwnProperty(option)) {
+      if (showdownOptions.hasOwnProperty(option) && (typeof showdownOptions[option]) !== 'undefined') {
         this.converter.setOption(option, showdownOptions[option]);
       }
     }

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -56,9 +56,29 @@ test('supports setting showdown options', function(assert) {
     component.set('strikethrough', true);
   });
 
-  let expectedHtml = '<h3 id="title">title</h3>\n\n<p>I <del>dislike</del> enjoy visiting <a href="http://www.google.com">http://www.google.com</a></p>';
+  let expectedHtml = '<h3 id="title">title</h3>\n<p>I <del>dislike</del> enjoy visiting <a href="http://www.google.com">http://www.google.com</a></p>';
 
   assert.equal(component.get('html').toString(), expectedHtml);
+});
+
+test('does not reset default showdown options with undefined', function(assert) {
+  assert.expect(1);
+
+  let originalStrikeThroughValue = showdown.getOption('strikethrough');
+  showdown.setOption('strikethrough', true);
+
+  let component = this.subject();
+  this.append();
+
+  Ember.run(function() {
+    component.set('markdown', '~~dislike~~');
+  });
+
+  let expectedHtml = '<p><del>dislike</del></p>';
+
+  assert.equal(component.get('html').toString(), expectedHtml);
+
+  showdown.setOption('strikethrough', originalStrikeThroughValue);
 });
 
 test('it supports loading showdown extensions', function(assert) {
@@ -127,14 +147,10 @@ test('it does not munge code fences', function(assert) {
   this.append();
 
   Ember.run(function() {
-    component.set("markdown", "```html" +
-     "<strong>hello</strong>\n" +
-     "<em>world</em>\n" +
-     "```");
+    component.set("ghCodeBlocks", true);
+    component.set("markdown", "```html\n<strong>hello</strong>\n<em>world</em>\n```");
   });
 
-  let expectedHtml = "<p><code>html&lt;strong&gt;hello&lt;/strong&gt;\n" +
-        "&lt;em&gt;world&lt;/em&gt;\n" +
-        "</code></p>";
+  let expectedHtml = "<pre><code class=\"html language-html\">&lt;strong&gt;hello&lt;/strong&gt;\n&lt;em&gt;world&lt;/em&gt;\n</code></pre>";
   assert.equal(component.get('html').toString(), expectedHtml);
 });


### PR DESCRIPTION
#38

The test comes in a separate commit so that you can check it out to ensure the test case fails, and then check out the other commit to see it fixed.

The test commit also contains fixes for a couple incorrect tests.