### PR TITLE
Fix for #38 GitHub code blocks are rendered incorrectly

### DIFF
--- a/addon/components/markdown-to-html.js
+++ b/addon/components/markdown-to-html.js
@@ -19,9 +19,9 @@ const ShowdownComponent = Ember.Component.extend({
   html: computed('markdown', 'converter', function() {
     let showdownOptions = this.getProperties(get(this, 'defaultOptionKeys'));
     let converter = get(this, 'converter');
- 
+
     for (let option in showdownOptions) {
-      if (showdownOptions.hasOwnProperty(option)) {
+      if (showdownOptions.hasOwnProperty(option) && (typeof showdownOptions[option]) !== 'undefined') {
         converter.setOption(option, showdownOptions[option]);
       }
     }

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -85,6 +85,27 @@ test('it supports loading showdown extensions', function(assert) {
   assert.equal(component.get('html').toString(), expectedHtml);
 });
 
+test('does not reset default showdown options with undefined', function(assert) {
+  assert.expect(1);
+
+  let originalStrikeThroughValue = showdown.getOption('strikethrough');
+  showdown.setOption('strikethrough', true);
+
+  let component = this.subject();
+  this.append();
+
+  Ember.run(function() {
+    component.set('markdown', '~~dislike~~');
+  });
+
+  let expectedHtml = '<p><del>dislike</del></p>';
+
+  assert.equal(component.get('html').toString(), expectedHtml);
+
+  showdown.setOption('strikethrough', originalStrikeThroughValue);
+});
+
+
 test('it supports loading showdown extensions', function(assert) {
   assert.expect(1);
 

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -56,7 +56,7 @@ test('supports setting showdown options', function(assert) {
     component.set('strikethrough', true);
   });
 
-  let expectedHtml = '<h3 id="title">title</h3>\n\n<p>I <del>dislike</del> enjoy visiting <a href="http://www.google.com">http://www.google.com</a></p>';
+  let expectedHtml = '<h3 id="title">title</h3>\n<p>I <del>dislike</del> enjoy visiting <a href="http://www.google.com">http://www.google.com</a></p>';
 
   assert.equal(component.get('html').toString(), expectedHtml);
 });

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -127,14 +127,10 @@ test('it does not munge code fences', function(assert) {
   this.append();
 
   Ember.run(function() {
-    component.set("markdown", "```html" +
-     "<strong>hello</strong>\n" +
-     "<em>world</em>\n" +
-     "```");
+    component.set("ghCodeBlocks", true);
+    component.set("markdown", "```html\n<strong>hello</strong>\n<em>world</em>\n```");
   });
 
-  let expectedHtml = "<p><code>html&lt;strong&gt;hello&lt;/strong&gt;\n" +
-        "&lt;em&gt;world&lt;/em&gt;\n" +
-        "</code></p>";
+  let expectedHtml = "<pre><code class=\"html language-html\">&lt;strong&gt;hello&lt;/strong&gt;\n&lt;em&gt;world&lt;/em&gt;\n</code></pre>";
   assert.equal(component.get('html').toString(), expectedHtml);
 });

--- a/tests/unit/components/markdown-to-html-test.js
+++ b/tests/unit/components/markdown-to-html-test.js
@@ -38,9 +38,10 @@ test('it inserts <br> tag', function(assert) {
     component.set('markdown', 'foo  \nbar');
   });
 
-  let expectedHtml = '<p>foo <br />\nbar</p>';
+  let expectedHtmlRegex = /<p>foo ?<br \/>\nbar<\/p>/;
+  let actualHtml = component.get('html').toString();
 
-  assert.equal(component.get('html').toString(), expectedHtml);
+  assert.ok(expectedHtmlRegex.test(actualHtml));
 });
 
 test('supports setting showdown options', function(assert) {


### PR DESCRIPTION
This PR contains:

1. A couple fixes of existing test cases.
2. A failing test case for #38 so that you can check it out to ensure the test case fails.
3. Fix for #38 which satisfies the previous test case.