### PR TITLE
Modification of index.js included hook to retrieve the parent application

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,20 @@ module.exports = {
   included: function showdownIncluded(app) {
     this._super.included.apply(this, arguments);
 
-    var host = this._findHost();
+    var host;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      host = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      var current = this;
+      do {
+        host = current.app || host;
+      } while (current.parent.parent && (current = current.parent));
+    }
 
     if (isFastBoot()) {
       this.importFastBootDependencies(host);


### PR DESCRIPTION
With this fix we now allow the addon to find the parent application from another addons and in versions of ember lower than 2.7 where the findHost helper is not available. 

We are copying the old implementation of ember-cli