### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/gcollazo/ember-cli-showdown",
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
This fixes the wrong repo URL displaying on [Ember Observer](https://emberobserver.com) (and possibly elsewhere).