### PR TITLE
Fix for FastBoot beta

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,11 +43,9 @@ module.exports = {
       files: ['showdown.js', 'showdown.js.map']
     }));
 
-    if (legacyIsFastboot()) {
-      trees.push(funnel(path.join(__dirname, './public'), {
-        files: ['fastboot-showdown.js']
-      }));
-    }
+    trees.push(funnel(path.join(__dirname, './public'), {
+      files: ['fastboot-showdown.js']
+    }));
 
     return mergeTrees(trees);
   },


### PR DESCRIPTION
Seems you cannot rely on `EMBER_CLI_FASTBOOT` being set correctly in `treeForVendor`. That hook was called just once (with `EMBER_CLI_FASTBOOT` being `undefined`), while `included` got called twice (for browser and FastBoot builds, with `EMBER_CLI_FASTBOOT` correctly set). 

That caused this exception for me: 
```
Error: ENOENT: no such file or directory, open '/Users/simonihmig/Projects/tlw/tmp/source_map_concat-input_base_path-d7N9FNMf.tmp/vendor/fastboot-showdown.js'
``` 

Moving that file to vendor regardless of build target (browser/FastBoot) should not matter, as it is still only imported for FastBoot builds...