### PR TITLE
Remove sourceMappingURL for showdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,10 +54,14 @@ module.exports = {
        */
       return stringReplace(showdownTree, {
         files: ['showdown.js'],
-        pattern: {
+        patterns: [{
           match: /typeof module !== 'undefined'/g,
           replacement: 'false'
-        }
+        },
+        {
+          match: /\/\/# sourceMappingURL=showdown.js.map/g,
+          replacement: ''
+        }]
       });
     }
   }


### PR DESCRIPTION
Trying to build our app that uses ember-cli-showdown with ember-cli-uglify@2.0.0 results in this error:

> Error: ENOENT: no such file or directory, open '/tmp/build_6cc7dc214277453a580cd882a48b6d24/fb52bf4fa3db7ca893b6657aff4733087b2878fb/tmp/uglify_writer-input_base_path-mvvjRQhP.tmp/assets/showdown.js.map'

Similar issues have been [reported upstream](https://github.com/ember-cli/ember-cli-uglify/issues/29) in ember-cli-uglify but it seems as though what is happening here is actually exposing an existing issue.  I was able to fix this by following a similar solution as was done [here](https://github.com/toddjordan/ember.js/commit/835e9dfa0f03f6e8339b8ba5cd5ed9aaea64e07e) to fix a similar problem in Ember itself.  