### PR TITLE
move ember-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "broccoli-funnel": "^2.0.0",
     "broccoli-source": "^1.1.0",
     "broccoli-string-replace": "^0.1.2",
-    "ember-cli": "^2.18.2",
     "ember-cli-babel": "^6.8.1",
     "ember-cli-htmlbars": "^2.0.3",
     "ember-cli-import-polyfill": "^0.2.0",
@@ -36,6 +35,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "ember-cli": "^2.18.2",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",


### PR DESCRIPTION
This prevents duplicate versions of ember-cli being installed with the version used by a consuming application.