### PR TITLE
remove ember-source from peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,7 @@
     "stylelint-prettier": "^4.0.2",
     "webpack": "^5.89.0"
   },
-  "peerDependencies": {
-    "ember-source": ">= 3.12.0"
-  },
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
+  "packageManager": "pnpm@10.17.1+sha512.17c560fca4867ae9473a3899ad84a88334914f379be46d455cbf92e5cf4b39d34985d452d2583baf19967fa76cb5c17bc9e245529d0b98745721aa7200ecaf7a",
   "engines": {
     "node": ">= 18"
   },


### PR DESCRIPTION
this will never be used as a true peer and will only cause problems for people (espcially in monorepos)